### PR TITLE
execute inline scripts in ajax overlay

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,19 @@ Changelog
 1.3.3 (unreleased)
 ------------------
 
+- Now execute inline scripts in ajax overlay.
+  [vincentfretin]
+
+- Give the pbo object as second parameter for noform callback. You can access
+  everything from it, for example the overlay trigger pbo.source.
+  [vincentfretin]
+
+- Give the disconnected "el" jQuery object (the div created with the html
+  response) instead of "this" (the request object) to the noform and redirect
+  callbacks. This fixes the noformerrorshow callback from popupforms.js in the
+  Products.CMFPlone package.
+  [vincentfretin]
+
 - Call ploneTabInit when a form is reloaded with errors.
   [vincentfretin]
 


### PR DESCRIPTION
I made the changes in the 1.3 branch because I work on Plone 4.2.3.
The commit can easily be merged to master with cherry-pick.

With the proposed changes, we now have a working z3cform form with datepicker, master select and autocomplete widgets in overlay!

You need this css to be able to see the Dexterity datepicker:
```<style type="text/css">                                                         
# calroot {

  z-index: 99999;  
}  
</style>```

changelog:
- Give the disconnected "el" jQuery object (the div created with the html response) instead of "this" (the request object) to the noform and redirect callbacks. This fixes the noformerrorshow callback from popupforms.js in the Products.CMFPlone package.
- Give the pbo object as second parameter for noform callback. You can access everything from it, for example the overlay trigger pbo.source.
- Now execute inline scripts in ajax overlay.
