### PR TITLE
Disable overlays.css to match upgradestep

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Disabled overlays.css to match upgradestep.
 
 
 1.9.2 (2017-06-28)

--- a/plone/app/jquerytools/profiles/default/cssregistry.xml
+++ b/plone/app/jquerytools/profiles/default/cssregistry.xml
@@ -5,7 +5,7 @@
         id="++resource++plone.app.jquerytools.overlays.css"
         media="screen" rel="stylesheet" rendering="link"
         cacheable="True" compression="safe" cookable="True"
-        enabled="1" expression=""/>
+        enabled="0" expression=""/>
 
     <stylesheet title=""
         id="++resource++plone.app.jquerytools.dateinput.css"


### PR DESCRIPTION
This resource is disabled in https://github.com/plone/plone.app.jquerytools/blob/master/plone/app/jquerytools/setuphandlers.py#L22,  so I'll just disabled it.